### PR TITLE
Add additional bindings and update signatures

### DIFF
--- a/example.carp
+++ b/example.carp
@@ -4,13 +4,13 @@
 (def x 10)
 
 (defn main []
-  (do (initscr)
+  (do (ignore (initscr))
       (start-color)
       (init-pair 1 COLOR_BLACK COLOR_RED)
       (init-pair 2 COLOR_BLUE COLOR_BLACK)
       (init-pair 3 COLOR_GREEN COLOR_WHITE)
       (attron (color-pair 1))
-      (refresh)
+      (ignore (refresh))
       (let [win (newwin 10 20 5 5)]
         (do
           ;;(wattron win (color-pair 3))
@@ -30,7 +30,7 @@
             (move 30 x)
             (printw @"@")
             )
-          (refresh)
-          (getch)
+          (ignore (refresh))
+          (ignore (getch))
           (update! x inc)))
       (endwin)))

--- a/ncurses.carp
+++ b/ncurses.carp
@@ -6,6 +6,9 @@
 (register-type SCREEN)
 
 (defmodule NCurses
+  (register ERR Int "ERR")
+  (register OK Int "OK")
+
   ;; Initialization functions (see curs_initscr)
   (register initscr (Fn [] (Ptr WINDOW)) "initscr")
   (register isendwin (Fn [] Bool) "isendwin")

--- a/ncurses.carp
+++ b/ncurses.carp
@@ -21,7 +21,6 @@
   (register endwin (Fn [] Int) "endwin")
 
   (register printw (Fn [String] ()) "printw") ;; memory leak, switch to (Ptr Char)
-  (register refresh (Fn [] ()) "refresh")
   (register move (Fn [Int Int] ()) "move")
 
   ;; Add character functions (see curs_addch)
@@ -52,6 +51,14 @@
   (register mvwgetch (Fn [(Ptr WINDOW) Int Int] Int) "mvwgetch")
   (register ungetch (Fn [Int] Int) "ungetch")
   (register has-key (Fn [Int] Int) "has_key")
+
+  ;; Refresh functions
+  (register refresh (Fn [] Int) "refresh")
+  (register wrefresh (Fn [(Ptr WINDOW)] Int) "wrefresh")
+  (register wnoutrefresh (Fn [(Ptr WINDOW)] Int) "wnoutrefresh")
+  (register doupdate (Fn [] Int) "doupdate")
+  (register redrawwin (Fn [(Ptr WINDOW)] Int) "redrawwin")
+  (register wredrawln (Fn [(Ptr WINDOW) Int Int] Int) "wredrawln")
 
   ;; From ncurses_helper.h
   (register width (Fn [] Int))

--- a/ncurses.carp
+++ b/ncurses.carp
@@ -9,6 +9,8 @@
 (defmodule NCurses
   (register ERR Int "ERR")
   (register OK Int "OK")
+  (register TRUE Int "TRUE")
+  (register FALSE Int "FALSE")
 
   ;; Initialization functions (see curs_initscr)
   (register initscr (Fn [] (Ptr WINDOW)) "initscr")
@@ -20,7 +22,6 @@
 
   (register printw (Fn [String] ()) "printw") ;; memory leak, switch to (Ptr Char)
   (register refresh (Fn [] ()) "refresh")
-  (register getch (Fn [] ()) "getch")
   (register move (Fn [Int Int] ()) "move")
 
   ;; Add character functions (see curs_addch)
@@ -43,6 +44,14 @@
   (register mvwaddstr (Fn [(Ptr WINDOW) Int Int String] Int) "mvwaddstr")
   (register mvwaddnstr (Fn [(Ptr WINDOW) Int Int String Int] Int)
   "mvwaddnstr")
+
+  ;; Get character functions
+  (register getch (Fn [] Int) "getch")
+  (register wgetch (Fn [(Ptr WINDOW)] Int) "wgetch")
+  (register mvgetch (Fn [Int Int] Int) "mvgetch")
+  (register mvwgetch (Fn [(Ptr WINDOW) Int Int] Int) "mvwgetch")
+  (register ungetch (Fn [Int] Int) "ungetch")
+  (register has-key (Fn [Int] Int) "has_key")
 
   ;; From ncurses_helper.h
   (register width (Fn [] Int))

--- a/ncurses.carp
+++ b/ncurses.carp
@@ -4,6 +4,7 @@
 
 (register-type WINDOW)
 (register-type SCREEN)
+(register-type chtype)
 
 (defmodule NCurses
   (register ERR Int "ERR")
@@ -21,6 +22,15 @@
   (register refresh (Fn [] ()) "refresh")
   (register getch (Fn [] ()) "getch")
   (register move (Fn [Int Int] ()) "move")
+
+  ;; Add character functions (see curs_addch)
+  ;; Each of these functions returns an Int indicating success or failure.
+  (register addch (Fn [chtype] Int) "addch")
+  (register waddch (Fn [(Ptr WINDOW) chtype] Int) "waddch")
+  (register mvaddch (Fn [Int Int chtype] Int) "mvaddch")
+  (register mvwaddch (Fn [(Ptr WINDOW) Int Int chtype] Int) "mvwaddch")
+  (register echochar (Fn [chtype] Int) "echochar")
+  (register wechochar (Fn [(Ptr WINDOW) chtype] Int) "wechochar")
 
   ;; Add string functions (see curs_addstr)
   ;; Each of these functions returns an Int indicating success or failure.

--- a/ncurses.carp
+++ b/ncurses.carp
@@ -6,7 +6,7 @@
 (register-type SCREEN)
 
 (defmodule NCurses
-  ;; Initialization functions
+  ;; Initialization functions (see curs_initscr)
   (register initscr (Fn [] (Ptr WINDOW)) "initscr")
   (register isendwin (Fn [] Bool) "isendwin")
   (register newterm (Fn [String (Ptr FILE) (Ptr FILE)] (Ptr SCREEN)) "newterm")
@@ -18,6 +18,18 @@
   (register refresh (Fn [] ()) "refresh")
   (register getch (Fn [] ()) "getch")
   (register move (Fn [Int Int] ()) "move")
+
+  ;; Add string functions (see curs_addstr)
+  ;; Each of these functions returns an Int indicating success or failure.
+  (register addstr (Fn [String] Int) "addstr")
+  (register addnstr (Fn [String Int] Int) "addnstr")
+  (register waddstr (Fn [(Ptr WINDOW) String] Int) "waddstr")
+  (register waddnstr (Fn [(Ptr WINDOW) String Int] Int) "waddnstr")
+  (register mvaddstr (Fn [Int Int String] Int) "mvaddstr")
+  (register mvaddnstr (Fn [Int Int String Int] Int) "mvaddnstr")
+  (register mvwaddstr (Fn [(Ptr WINDOW) Int Int String] Int) "mvwaddstr")
+  (register mvwaddnstr (Fn [(Ptr WINDOW) Int Int String Int] Int)
+  "mvwaddnstr")
 
   ;; From ncurses_helper.h
   (register width (Fn [] Int))

--- a/ncurses.carp
+++ b/ncurses.carp
@@ -3,13 +3,20 @@
 (add-lib "-lncurses")
 
 (register-type WINDOW)
+(register-type SCREEN)
 
 (defmodule NCurses
-  (register initscr (Fn [] ()) "initscr")
+  ;; Initialization functions
+  (register initscr (Fn [] (Ptr WINDOW)) "initscr")
+  (register isendwin (Fn [] Bool) "isendwin")
+  (register newterm (Fn [String (Ptr FILE) (Ptr FILE)] (Ptr SCREEN)) "newterm")
+  (register set-term (Fn [(Ptr SCREEN)] (Ptr SCREEN)) "set_term")
+  (register delscreen (Fn [(Ptr SCREEN)] ()) "delscreen")
+  (register endwin (Fn [] Int) "endwin")
+
   (register printw (Fn [String] ()) "printw") ;; memory leak, switch to (Ptr Char)
   (register refresh (Fn [] ()) "refresh")
   (register getch (Fn [] ()) "getch")
-  (register endwin (Fn [] ()) "endwin")
   (register move (Fn [Int Int] ()) "move")
 
   ;; From ncurses_helper.h


### PR DESCRIPTION
This PR adds a couple more bindings following the ncursses man page organization, it adds:

- initialization family functions (functions listed in `man curs_initscr`) 
- `addch` family functions (functions listed in `man curs_addch`)
- `addstr` family functions (functions listed in `man curs_addstr`)
- `getch` family functions (functions listed in `man curs_getch`)
- `refresh` family functions (functions listed in `man curs_refresh`)

I've also added type and macro bindings as needed, and  updated the signatures of existing bindings to match the ncurses signatures more precisely (most functions return an `int` indicating whether or not the operation succeeded or failed, and `intiscr` now returns a pointer to the Window). I've updated `example.carp` to account for the signature changes.