### PR TITLE
Reorganize source, add more bindings

### DIFF
--- a/example.carp
+++ b/example.carp
@@ -5,11 +5,11 @@
 
 (defn main []
   (do (ignore (initscr))
-      (start-color)
-      (init-pair 1 COLOR_BLACK COLOR_RED)
-      (init-pair 2 COLOR_BLUE COLOR_BLACK)
-      (init-pair 3 COLOR_GREEN COLOR_WHITE)
-      (attron (color-pair 1))
+      (ignore (start-color))
+      (ignore (init-pair (from-int 1) COLOR_BLACK COLOR_RED))
+      (ignore (init-pair (from-int 2) COLOR_BLUE COLOR_BLACK))
+      (ignore (init-pair (from-int 3) COLOR_GREEN COLOR_WHITE))
+      (ignore (attron (color-pair 1)))
       (ignore (refresh))
       (let [win (newwin 10 20 5 5)]
         (do

--- a/lib/addch.carp
+++ b/lib/addch.carp
@@ -1,0 +1,10 @@
+;; Add character functions (see curs_addch)
+;; Each of these functions returns an Int indicating success or failure.
+(defmodule NCurses
+  (register addch (Fn [Chtype] Int) "addch")
+  (register waddch (Fn [(Ptr WINDOW) Chtype] Int) "waddch")
+  (register mvaddch (Fn [Int Int Chtype] Int) "mvaddch")
+  (register mvwaddch (Fn [(Ptr WINDOW) Int Int Chtype] Int) "mvwaddch")
+  (register echochar (Fn [Chtype] Int) "echochar")
+  (register wechochar (Fn [(Ptr WINDOW) Chtype] Int) "wechochar")
+)

--- a/lib/addstr.carp
+++ b/lib/addstr.carp
@@ -1,0 +1,12 @@
+;; Add string functions (see curs_addstr)
+;; Each of these functions returns an Int indicating success or failure.
+(defmodule NCurses
+  (register addstr (Fn [String] Int) "addstr")
+  (register addnstr (Fn [String Int] Int) "addnstr")
+  (register waddstr (Fn [(Ptr WINDOW) String] Int) "waddstr")
+  (register waddnstr (Fn [(Ptr WINDOW) String Int] Int) "waddnstr")
+  (register mvaddstr (Fn [Int Int String] Int) "mvaddstr")
+  (register mvaddnstr (Fn [Int Int String Int] Int) "mvaddnstr")
+  (register mvwaddstr (Fn [(Ptr WINDOW) Int Int String] Int) "mvwaddstr")
+  (register mvwaddnstr (Fn [(Ptr WINDOW) Int Int String Int] Int) "mvwaddnstr")
+)

--- a/lib/attr.carp
+++ b/lib/attr.carp
@@ -1,0 +1,40 @@
+;; Attr functions (see curs_attr)
+;; N.B. Many of the curs_attr functions take a void pointer as their final
+;; argument. The man pages I have, circa ncurses 6.1, state that only
+;; "functions that modify the color" and "functions that retrieve the color"
+;; use this final argument, and when used, expect an int pointer.
+;;
+;; All other functions don't make use of the argument at all, "except to check
+;; that it is null"
+;;
+;; So, as a result, the signatures of bindings for functions that take the
+;; final void pointer as an argument take a `(Ptr Int)` since we can pass NULL
+;; for the functions that don't use the argument, and an Int Pointer for those
+;; that do.
+(defmodule NCurses
+  (register attr-ptr (Fn [] (Ptr Attribute)) "NCurses_attr_ptr")
+  (register attr-get (Fn [(Ptr Attribute) (Ptr Short) (Ptr Int)] Int) "attr_get")
+  (register wattr-get (Fn [(Ptr WINDOW) (Ptr Attribute) (Ptr Short) (Ptr Int)] Int) "wattr_get")
+  (register attr-set (Fn [(Ptr Attribute) Short (Ptr Int)] Int) "attr_set")
+  (register wattr-set (Fn [(Ptr WINDOW) (Ptr Attribute) Short (Ptr Int)] Int) "wattr_set")
+  (register attr-off (Fn [Attribute (Ptr Int)] Int) "attr_off")
+  (register wattr-off (Fn [(Ptr WINDOW) Attribute (Ptr Int)] Int) "wattr_off")
+  (register attr-on (Fn [Attribute (Ptr Int)] Int) "attr_on")
+  (register wattr-on (Fn [(Ptr WINDOW) Attribute (Ptr Int)] Int) "wattr_on")
+  (register attroff (Fn [Int] Int) "attroff")
+  (register wattroff (Fn [(Ptr WINDOW) Int] Int) "wattroff")
+  (register attron (Fn [Int] Int) "attron")
+  (register wattron (Fn [(Ptr WINDOW) Int] Int) "wattron")
+  (register attrset (Fn [Int] Int) "attrset")
+  (register wattrset (Fn [(Ptr WINDOW) Int] Int) "wattrset")
+  (register chgat (Fn [Int Attribute Short (Ptr Int)] Int) "chgat")
+  (register wchgat (Fn [(Ptr WINDOW) Int Attribute Short (Ptr Int)] Int) "wchgat")
+  (register mvchgat (Fn [Int Int Int Attribute Short (Ptr Int)] Int) "mvchgat")
+  (register mvwchgat (Fn [(Ptr WINDOW) Int Int Int Attribute Short (Ptr Int)] Int) "mvwchgat")
+  (register color-set (Fn [Short (Ptr Int)] Int) "color_set")
+  (register wcolor-set (Fn [(Ptr WINDOW) Short (Ptr Int)] Int) "wcolor_set")
+  (register standend (Fn [] Int) "standend")
+  (register wstandend (Fn [(Ptr WINDOW)] Int) "wstandend")
+  (register standout (Fn [] Int) "standout")
+  (register wstandout (Fn [(Ptr WINDOW)] Int) "wstandout")
+)

--- a/lib/color.carp
+++ b/lib/color.carp
@@ -1,0 +1,36 @@
+;; Color functions (see curs_color)
+(defmodule NCurses 
+  ;; COLORS is initialized to the maximum number of colors the terminal can
+  ;; support after a call to start-color
+  (register COLORS Int "COLORS")
+  ;; COLOR_PAIRS is initialized to the maximum number of color pairs the
+  ;; terminal can support after a call to start-color
+  (register COLOR_PAIRS Int "COLOR_PAIRS")
+  (register start-color (Fn [] Int) "start_color")
+  (register has-colors (Fn [] Bool) "has_colors")
+  (register can-change-color (Fn [] Bool) "can_change_color")
+  (register init-pair (Fn [Short Short Short] Int) "init_pair")
+  (register init-color (Fn [Short Short Short Short] Int) "init_color")
+  ;; extensions -- note that these actually accept ints instead of shorts
+  (register init-extended-pair (Fn [Int Int Int] int) "init_extended_pair")
+  (register init-extended-color (Fn [Int Int Int Int] int) "init_extended_color")
+  (register color-content (Fn [Short Short Short Short] Int) "color_content")
+  (register pair-content (Fn [Short Short Short] Int) "pair_content")
+  ;; extensions -- note that these actually accept ints instead of shorts
+  (register extended-color-content (Fn [Int Int Int Int] Int)
+  "extended_color_content")
+  (register extended-pair-content (Fn [Int Int Int] Int) "extended_pair_content")
+  ;; extension
+  (register reset-color-pairs (Fn [] ()) "reset_color_pairs")
+  (register color-pair (Fn [Int] Int) "COLOR_PAIR")
+  (register pair-number (Fn [Int] Int) "PAIR_NUMBER")
+  (register COLOR_BLACK Short "COLOR_BLACK")
+  (register COLOR_RED Short "COLOR_RED")
+  (register COLOR_RED Short "COLOR_RED")
+  (register COLOR_GREEN Short "COLOR_GREEN")
+  (register COLOR_YELLOW Short "COLOR_YELLOW")
+  (register COLOR_BLUE Short "COLOR_BLUE")
+  (register COLOR_MAGENTA Short "COLOR_MAGENTA")
+  (register COLOR_CYAN Short "COLOR_CYAN")
+  (register COLOR_WHITE Short "COLOR_WHITE")
+)

--- a/lib/getch.carp
+++ b/lib/getch.carp
@@ -1,0 +1,9 @@
+;; Get character functions (see curs_getch)
+(defmodule NCurses
+  (register getch (Fn [] Int) "getch")
+  (register wgetch (Fn [(Ptr WINDOW)] Int) "wgetch")
+  (register mvgetch (Fn [Int Int] Int) "mvgetch")
+  (register mvwgetch (Fn [(Ptr WINDOW) Int Int] Int) "mvwgetch")
+  (register ungetch (Fn [Int] Int) "ungetch")
+  (register has-key (Fn [Int] Int) "has_key")
+)

--- a/lib/init.carp
+++ b/lib/init.carp
@@ -1,0 +1,9 @@
+;; ncurses initialization functions (see curs_initscr)
+(defmodule NCurses
+  (register initscr (Fn [] (Ptr WINDOW)) "initscr")
+  (register isendwin (Fn [] Bool) "isendwin")
+  (register newterm (Fn [String (Ptr FILE) (Ptr FILE)] (Ptr SCREEN)) "newterm")
+  (register set-term (Fn [(Ptr SCREEN)] (Ptr SCREEN)) "set_term")
+  (register delscreen (Fn [(Ptr SCREEN)] ()) "delscreen")
+  (register endwin (Fn [] Int) "endwin")
+)

--- a/lib/refresh.carp
+++ b/lib/refresh.carp
@@ -1,0 +1,9 @@
+;; Refresh functions (see curs_refresh)
+(defmodule NCurses
+  (register refresh (Fn [] Int) "refresh")
+  (register wrefresh (Fn [(Ptr WINDOW)] Int) "wrefresh")
+  (register wnoutrefresh (Fn [(Ptr WINDOW)] Int) "wnoutrefresh")
+  (register doupdate (Fn [] Int) "doupdate")
+  (register redrawwin (Fn [(Ptr WINDOW)] Int) "redrawwin")
+  (register wredrawln (Fn [(Ptr WINDOW) Int Int] Int) "wredrawln")
+)

--- a/ncurses.carp
+++ b/ncurses.carp
@@ -5,6 +5,8 @@
 (register-type WINDOW)
 (register-type SCREEN)
 (register-type chtype)
+;; Just a synonym for chtype under the hood.
+(register-type Attribute)
 
 (defmodule NCurses
   (register ERR Int "ERR")
@@ -103,6 +105,45 @@
   (register COLOR_MAGENTA Int "COLOR_MAGENTA")
   (register COLOR_CYAN Int "COLOR_CYAN")
   (register COLOR_WHITE Int "COLOR_WHITE")
+
+  ;; Attr functions
+  ;; N.B. Many of the curs_attr functions take a void pointer as their final
+  ;; argument. The man pages I have, circa ncurses 6.1, state that only
+  ;; "functions that modify the color" and "functions that retrieve the color"
+  ;; use this final argument, and when used, expect an int pointer.
+  ;;
+  ;; All other functions don't make use of the argument at all, "except to check
+  ;; that it is null"
+  ;;
+  ;; So, as a result, the signatures of bindings for functions that take the
+  ;; final void pointer as an argument take a `(Ptr Int)` since we can pass NULL
+  ;; for the functions that don't use the argument, and an Int Pointer for those
+  ;; that do.
+  (register attr-ptr (Fn [] (Ptr Attribute)) "NCurses_attr_ptr")
+  (register attr-get (Fn [(Ptr Attribute) (Ptr Int) (Ptr Int)] Int) "attr_get")
+  (register wattr-get (Fn [(Ptr WINDOW) (Ptr attr_t) (Ptr Int) (Ptr Int)] Int) "wattr_get")
+  (register attr-set (Fn [(Ptr Attribute) Int (Ptr Int)] Int) "attr_set")
+  (register wattr-set (Fn [(Ptr WINDOW) (Ptr Attribute) Int (Ptr Int)] Int) "wattr_set")
+  (register attr-off (Fn [Attribute (Ptr Int)] Int) "attr_off")
+  (register wattr-off (Fn [(Ptr WINDOW) Attribute (Ptr Int)] Int) "wattr_off")
+  (register attr-on (Fn [Attribute (Ptr Int)] Int) "attr_on")
+  (register wattr-on (Fn [(Ptr WINDOW) Attribute (Ptr Int)] Int) "wattr_on")
+  (register attroff (Fn [Int] Int) "attroff")
+  (register wattroff (Fn [(Ptr WINDOW) Int] Int) "wattroff")
+  (register attron (Fn [Int] Int) "attron")
+  (register wattron (Fn [(Ptr WINDOW) Int] Int) "wattron")
+  (register attrset (Fn [Int] Int) "attrset")
+  (register wattrset (Fn [(Ptr WINDOW) Int] Int) "wattrset")
+  (register chgat (Fn [Int Attribute Int (Ptr Int)] Int) "chgat")
+  (register wchgat (Fn [(Ptr WINDOW) Int Attribute Int (Ptr Int)] Int) "wchgat")
+  (register mvchgat (Fn [Int Int Int Attribute Int (Ptr Int)] Int) "mvchgat")
+  (register mvwchgat (Fn [(Ptr WINDOW) Int Int Int Attribute Int (Ptr Int)] Int) "mvwchgat")
+  (register color-set (Fn [Int (Ptr Int)] Int) "color_set")
+  (register wcolor-set (Fn [(Ptr WINDOW) Int (Ptr Int)] Int) "wcolor_set")
+  (register standend (Fn [] Int) "standend")
+  (register wstandend (Fn [(Ptr WINDOW)] Int) "wstandend")
+  (register standout (Fn [] Int) "standout")
+  (register wstandout (Fn [(Ptr WINDOW)] Int) "wstandout")
 
   ;; Windows
   (register wbkgd (Fn [(Ptr WINDOW) Int] ()) "wbkgd")

--- a/ncurses.carp
+++ b/ncurses.carp
@@ -9,138 +9,26 @@
 (register-type Attribute)
 (register-type Short)
 
+(load "lib/addch.carp")
+(load "lib/addstr.carp")
+(load "lib/attr.carp")
+(load "lib/color.carp")
+(load "lib/getch.carp")
+(load "lib/init.carp")
+(load "lib/refresh.carp")
+
 (defmodule NCurses
   (register ERR Int "ERR")
   (register OK Int "OK")
   (register TRUE Int "TRUE")
   (register FALSE Int "FALSE")
-
-  ;; Initialization functions (see curs_initscr)
-  (register initscr (Fn [] (Ptr WINDOW)) "initscr")
-  (register isendwin (Fn [] Bool) "isendwin")
-  (register newterm (Fn [String (Ptr FILE) (Ptr FILE)] (Ptr SCREEN)) "newterm")
-  (register set-term (Fn [(Ptr SCREEN)] (Ptr SCREEN)) "set_term")
-  (register delscreen (Fn [(Ptr SCREEN)] ()) "delscreen")
-  (register endwin (Fn [] Int) "endwin")
-
+  
   (register printw (Fn [String] ()) "printw") ;; memory leak, switch to (Ptr Char)
   (register move (Fn [Int Int] ()) "move")
-
-  ;; Add character functions (see curs_addch)
-  ;; Each of these functions returns an Int indicating success or failure.
-  (register addch (Fn [Chtype] Int) "addch")
-  (register waddch (Fn [(Ptr WINDOW) Chtype] Int) "waddch")
-  (register mvaddch (Fn [Int Int Chtype] Int) "mvaddch")
-  (register mvwaddch (Fn [(Ptr WINDOW) Int Int Chtype] Int) "mvwaddch")
-  (register echochar (Fn [Chtype] Int) "echochar")
-  (register wechochar (Fn [(Ptr WINDOW) Chtype] Int) "wechochar")
-
-  ;; Add string functions (see curs_addstr)
-  ;; Each of these functions returns an Int indicating success or failure.
-  (register addstr (Fn [String] Int) "addstr")
-  (register addnstr (Fn [String Int] Int) "addnstr")
-  (register waddstr (Fn [(Ptr WINDOW) String] Int) "waddstr")
-  (register waddnstr (Fn [(Ptr WINDOW) String Int] Int) "waddnstr")
-  (register mvaddstr (Fn [Int Int String] Int) "mvaddstr")
-  (register mvaddnstr (Fn [Int Int String Int] Int) "mvaddnstr")
-  (register mvwaddstr (Fn [(Ptr WINDOW) Int Int String] Int) "mvwaddstr")
-  (register mvwaddnstr (Fn [(Ptr WINDOW) Int Int String Int] Int)
-  "mvwaddnstr")
-
-  ;; Get character functions
-  (register getch (Fn [] Int) "getch")
-  (register wgetch (Fn [(Ptr WINDOW)] Int) "wgetch")
-  (register mvgetch (Fn [Int Int] Int) "mvgetch")
-  (register mvwgetch (Fn [(Ptr WINDOW) Int Int] Int) "mvwgetch")
-  (register ungetch (Fn [Int] Int) "ungetch")
-  (register has-key (Fn [Int] Int) "has_key")
-
-  ;; Refresh functions
-  (register refresh (Fn [] Int) "refresh")
-  (register wrefresh (Fn [(Ptr WINDOW)] Int) "wrefresh")
-  (register wnoutrefresh (Fn [(Ptr WINDOW)] Int) "wnoutrefresh")
-  (register doupdate (Fn [] Int) "doupdate")
-  (register redrawwin (Fn [(Ptr WINDOW)] Int) "redrawwin")
-  (register wredrawln (Fn [(Ptr WINDOW) Int Int] Int) "wredrawln")
 
   ;; From ncurses_helper.h
   (register width (Fn [] Int))
   (register height (Fn [] Int))
-
-  ;; Color functions (see curs_color)
-  ;; COLORS is initialized to the maximum number of colors the terminal can
-  ;; support after a call to start-color
-  (register COLORS Int "COLORS")
-  ;; COLOR_PAIRS is initialized to the maximum number of color pairs the
-  ;; terminal can support after a call to start-color
-  (register COLOR_PAIRS Int "COLOR_PAIRS")
-  (register start-color (Fn [] Int) "start_color")
-  (register has-colors (Fn [] Bool) "has_colors")
-  (register can-change-color (Fn [] Bool) "can_change_color")
-  (register init-pair (Fn [Short Short Short] Int) "init_pair")
-  (register init-color (Fn [Short Short Short Short] Int) "init_color")
-  ;; extensions -- note that these actually accept ints instead of shorts
-  (register init-extended-pair (Fn [Int Int Int] int) "init_extended_pair")
-  (register init-extended-color (Fn [Int Int Int Int] int) "init_extended_color")
-  (register color-content (Fn [Short Short Short Short] Int) "color_content")
-  (register pair-content (Fn [Short Short Short] Int) "pair_content")
-  ;; extensions -- note that these actually accept ints instead of shorts
-  (register extended-color-content (Fn [Int Int Int Int] Int)
-  "extended_color_content")
-  (register extended-pair-content (Fn [Int Int Int] Int) "extended_pair_content")
-  ;; extension
-  (register reset-color-pairs (Fn [] ()) "reset_color_pairs")
-  (register color-pair (Fn [Int] Int) "COLOR_PAIR")
-  (register pair-number (Fn [Int] Int) "PAIR_NUMBER")
-  (register attron (Fn [Int] ()) "attron")
-  (register COLOR_BLACK Int "COLOR_BLACK")
-  (register COLOR_RED Int "COLOR_RED")
-  (register COLOR_RED Int "COLOR_RED")
-  (register COLOR_GREEN Int "COLOR_GREEN")
-  (register COLOR_YELLOW Int "COLOR_YELLOW")
-  (register COLOR_BLUE Int "COLOR_BLUE")
-  (register COLOR_MAGENTA Int "COLOR_MAGENTA")
-  (register COLOR_CYAN Int "COLOR_CYAN")
-  (register COLOR_WHITE Int "COLOR_WHITE")
-
-  ;; Attr functions
-  ;; N.B. Many of the curs_attr functions take a void pointer as their final
-  ;; argument. The man pages I have, circa ncurses 6.1, state that only
-  ;; "functions that modify the color" and "functions that retrieve the color"
-  ;; use this final argument, and when used, expect an int pointer.
-  ;;
-  ;; All other functions don't make use of the argument at all, "except to check
-  ;; that it is null"
-  ;;
-  ;; So, as a result, the signatures of bindings for functions that take the
-  ;; final void pointer as an argument take a `(Ptr Int)` since we can pass NULL
-  ;; for the functions that don't use the argument, and an Int Pointer for those
-  ;; that do.
-  (register attr-ptr (Fn [] (Ptr Attribute)) "NCurses_attr_ptr")
-  (register attr-get (Fn [(Ptr Attribute) (Ptr Short) (Ptr Int)] Int) "attr_get")
-  (register wattr-get (Fn [(Ptr WINDOW) (Ptr Attribute) (Ptr Short) (Ptr Int)] Int) "wattr_get")
-  (register attr-set (Fn [(Ptr Attribute) Short (Ptr Int)] Int) "attr_set")
-  (register wattr-set (Fn [(Ptr WINDOW) (Ptr Attribute) Short (Ptr Int)] Int) "wattr_set")
-  (register attr-off (Fn [Attribute (Ptr Int)] Int) "attr_off")
-  (register wattr-off (Fn [(Ptr WINDOW) Attribute (Ptr Int)] Int) "wattr_off")
-  (register attr-on (Fn [Attribute (Ptr Int)] Int) "attr_on")
-  (register wattr-on (Fn [(Ptr WINDOW) Attribute (Ptr Int)] Int) "wattr_on")
-  (register attroff (Fn [Int] Int) "attroff")
-  (register wattroff (Fn [(Ptr WINDOW) Int] Int) "wattroff")
-  (register attron (Fn [Int] Int) "attron")
-  (register wattron (Fn [(Ptr WINDOW) Int] Int) "wattron")
-  (register attrset (Fn [Int] Int) "attrset")
-  (register wattrset (Fn [(Ptr WINDOW) Int] Int) "wattrset")
-  (register chgat (Fn [Int Attribute Short (Ptr Int)] Int) "chgat")
-  (register wchgat (Fn [(Ptr WINDOW) Int Attribute Short (Ptr Int)] Int) "wchgat")
-  (register mvchgat (Fn [Int Int Int Attribute Short (Ptr Int)] Int) "mvchgat")
-  (register mvwchgat (Fn [(Ptr WINDOW) Int Int Int Attribute Short (Ptr Int)] Int) "mvwchgat")
-  (register color-set (Fn [Short (Ptr Int)] Int) "color_set")
-  (register wcolor-set (Fn [(Ptr WINDOW) Short (Ptr Int)] Int) "wcolor_set")
-  (register standend (Fn [] Int) "standend")
-  (register wstandend (Fn [(Ptr WINDOW)] Int) "wstandend")
-  (register standout (Fn [] Int) "standout")
-  (register wstandout (Fn [(Ptr WINDOW)] Int) "wstandout")
 
   ;; Windows
   (register wbkgd (Fn [(Ptr WINDOW) Int] ()) "wbkgd")
@@ -149,4 +37,4 @@
   (register wrefresh (Fn [(Ptr WINDOW)] ()) "wrefresh")
   (register box (Fn [(Ptr WINDOW) Int Int] ()) "box")
   (register mvwprintw (Fn [(Ptr WINDOW) Int Int String] ()) "mvwprintw") ;; Leak!
-  )
+)

--- a/ncurses.carp
+++ b/ncurses.carp
@@ -4,9 +4,10 @@
 
 (register-type WINDOW)
 (register-type SCREEN)
-(register-type chtype)
+(register-type Chtype)
 ;; Just a synonym for chtype under the hood.
 (register-type Attribute)
+(register-type Short)
 
 (defmodule NCurses
   (register ERR Int "ERR")
@@ -27,12 +28,12 @@
 
   ;; Add character functions (see curs_addch)
   ;; Each of these functions returns an Int indicating success or failure.
-  (register addch (Fn [chtype] Int) "addch")
-  (register waddch (Fn [(Ptr WINDOW) chtype] Int) "waddch")
-  (register mvaddch (Fn [Int Int chtype] Int) "mvaddch")
-  (register mvwaddch (Fn [(Ptr WINDOW) Int Int chtype] Int) "mvwaddch")
-  (register echochar (Fn [chtype] Int) "echochar")
-  (register wechochar (Fn [(Ptr WINDOW) chtype] Int) "wechochar")
+  (register addch (Fn [Chtype] Int) "addch")
+  (register waddch (Fn [(Ptr WINDOW) Chtype] Int) "waddch")
+  (register mvaddch (Fn [Int Int Chtype] Int) "mvaddch")
+  (register mvwaddch (Fn [(Ptr WINDOW) Int Int Chtype] Int) "mvwaddch")
+  (register echochar (Fn [Chtype] Int) "echochar")
+  (register wechochar (Fn [(Ptr WINDOW) Chtype] Int) "wechochar")
 
   ;; Add string functions (see curs_addstr)
   ;; Each of these functions returns an Int indicating success or failure.
@@ -76,17 +77,13 @@
   (register start-color (Fn [] Int) "start_color")
   (register has-colors (Fn [] Bool) "has_colors")
   (register can-change-color (Fn [] Bool) "can_change_color")
-  ;; TODO: init_pair takes shorts, make sure Int is ok.
-  (register init-pair (Fn [Int Int Int] Int) "init_pair")
-  ;; TODO: init_color takes shorts, make sure Int is ok.
-  (register init-color (Fn [Int Int Int Int] Int) "init_color")
+  (register init-pair (Fn [Short Short Short] Int) "init_pair")
+  (register init-color (Fn [Short Short Short Short] Int) "init_color")
   ;; extensions -- note that these actually accept ints instead of shorts
   (register init-extended-pair (Fn [Int Int Int] int) "init_extended_pair")
   (register init-extended-color (Fn [Int Int Int Int] int) "init_extended_color")
-  ;; TODO: color_content takes shorts, make sure Int is ok.
-  (register color-content (Fn [Int Int Int Int] Int) "color_content")
-  ;; TODO: pair_content takes shorts, make sure Int is ok.
-  (register pair-content (Fn [Int Int Int] Int) "pair_content")
+  (register color-content (Fn [Short Short Short Short] Int) "color_content")
+  (register pair-content (Fn [Short Short Short] Int) "pair_content")
   ;; extensions -- note that these actually accept ints instead of shorts
   (register extended-color-content (Fn [Int Int Int Int] Int)
   "extended_color_content")
@@ -120,10 +117,10 @@
   ;; for the functions that don't use the argument, and an Int Pointer for those
   ;; that do.
   (register attr-ptr (Fn [] (Ptr Attribute)) "NCurses_attr_ptr")
-  (register attr-get (Fn [(Ptr Attribute) (Ptr Int) (Ptr Int)] Int) "attr_get")
-  (register wattr-get (Fn [(Ptr WINDOW) (Ptr attr_t) (Ptr Int) (Ptr Int)] Int) "wattr_get")
-  (register attr-set (Fn [(Ptr Attribute) Int (Ptr Int)] Int) "attr_set")
-  (register wattr-set (Fn [(Ptr WINDOW) (Ptr Attribute) Int (Ptr Int)] Int) "wattr_set")
+  (register attr-get (Fn [(Ptr Attribute) (Ptr Short) (Ptr Int)] Int) "attr_get")
+  (register wattr-get (Fn [(Ptr WINDOW) (Ptr Attribute) (Ptr Short) (Ptr Int)] Int) "wattr_get")
+  (register attr-set (Fn [(Ptr Attribute) Short (Ptr Int)] Int) "attr_set")
+  (register wattr-set (Fn [(Ptr WINDOW) (Ptr Attribute) Short (Ptr Int)] Int) "wattr_set")
   (register attr-off (Fn [Attribute (Ptr Int)] Int) "attr_off")
   (register wattr-off (Fn [(Ptr WINDOW) Attribute (Ptr Int)] Int) "wattr_off")
   (register attr-on (Fn [Attribute (Ptr Int)] Int) "attr_on")
@@ -134,12 +131,12 @@
   (register wattron (Fn [(Ptr WINDOW) Int] Int) "wattron")
   (register attrset (Fn [Int] Int) "attrset")
   (register wattrset (Fn [(Ptr WINDOW) Int] Int) "wattrset")
-  (register chgat (Fn [Int Attribute Int (Ptr Int)] Int) "chgat")
-  (register wchgat (Fn [(Ptr WINDOW) Int Attribute Int (Ptr Int)] Int) "wchgat")
-  (register mvchgat (Fn [Int Int Int Attribute Int (Ptr Int)] Int) "mvchgat")
-  (register mvwchgat (Fn [(Ptr WINDOW) Int Int Int Attribute Int (Ptr Int)] Int) "mvwchgat")
-  (register color-set (Fn [Int (Ptr Int)] Int) "color_set")
-  (register wcolor-set (Fn [(Ptr WINDOW) Int (Ptr Int)] Int) "wcolor_set")
+  (register chgat (Fn [Int Attribute Short (Ptr Int)] Int) "chgat")
+  (register wchgat (Fn [(Ptr WINDOW) Int Attribute Short (Ptr Int)] Int) "wchgat")
+  (register mvchgat (Fn [Int Int Int Attribute Short (Ptr Int)] Int) "mvchgat")
+  (register mvwchgat (Fn [(Ptr WINDOW) Int Int Int Attribute Short (Ptr Int)] Int) "mvwchgat")
+  (register color-set (Fn [Short (Ptr Int)] Int) "color_set")
+  (register wcolor-set (Fn [(Ptr WINDOW) Short (Ptr Int)] Int) "wcolor_set")
   (register standend (Fn [] Int) "standend")
   (register wstandend (Fn [(Ptr WINDOW)] Int) "wstandend")
   (register standout (Fn [] Int) "standout")

--- a/ncurses.carp
+++ b/ncurses.carp
@@ -64,11 +64,36 @@
   (register width (Fn [] Int))
   (register height (Fn [] Int))
 
-  ;; Colors
-  (register start-color (Fn [] ()) "start_color")
-  (register init-pair (Fn [Int Int Int] ()) "init_pair")
-  (register attron (Fn [Int] ()) "attron")
+  ;; Color functions (see curs_color)
+  ;; COLORS is initialized to the maximum number of colors the terminal can
+  ;; support after a call to start-color
+  (register COLORS Int "COLORS")
+  ;; COLOR_PAIRS is initialized to the maximum number of color pairs the
+  ;; terminal can support after a call to start-color
+  (register COLOR_PAIRS Int "COLOR_PAIRS")
+  (register start-color (Fn [] Int) "start_color")
+  (register has-colors (Fn [] Bool) "has_colors")
+  (register can-change-color (Fn [] Bool) "can_change_color")
+  ;; TODO: init_pair takes shorts, make sure Int is ok.
+  (register init-pair (Fn [Int Int Int] Int) "init_pair")
+  ;; TODO: init_color takes shorts, make sure Int is ok.
+  (register init-color (Fn [Int Int Int Int] Int) "init_color")
+  ;; extensions -- note that these actually accept ints instead of shorts
+  (register init-extended-pair (Fn [Int Int Int] int) "init_extended_pair")
+  (register init-extended-color (Fn [Int Int Int Int] int) "init_extended_color")
+  ;; TODO: color_content takes shorts, make sure Int is ok.
+  (register color-content (Fn [Int Int Int Int] Int) "color_content")
+  ;; TODO: pair_content takes shorts, make sure Int is ok.
+  (register pair-content (Fn [Int Int Int] Int) "pair_content")
+  ;; extensions -- note that these actually accept ints instead of shorts
+  (register extended-color-content (Fn [Int Int Int Int] Int)
+  "extended_color_content")
+  (register extended-pair-content (Fn [Int Int Int] Int) "extended_pair_content")
+  ;; extension
+  (register reset-color-pairs (Fn [] ()) "reset_color_pairs")
   (register color-pair (Fn [Int] Int) "COLOR_PAIR")
+  (register pair-number (Fn [Int] Int) "PAIR_NUMBER")
+  (register attron (Fn [Int] ()) "attron")
   (register COLOR_BLACK Int "COLOR_BLACK")
   (register COLOR_RED Int "COLOR_RED")
   (register COLOR_RED Int "COLOR_RED")

--- a/ncurses.carp
+++ b/ncurses.carp
@@ -26,6 +26,7 @@
   (register printw (Fn [String] ()) "printw") ;; memory leak, switch to (Ptr Char)
   (register move (Fn [Int Int] ()) "move")
 
+  (register from-int (Fn [Int] Short))
   ;; From ncurses_helper.h
   (register width (Fn [] Int))
   (register height (Fn [] Int))

--- a/ncurses_helper.h
+++ b/ncurses_helper.h
@@ -13,6 +13,10 @@ typedef attr_t Attribute;
 typedef chtype Chtype;
 typedef short Short;
 
+Short NCurses_from_MINUS_int(int x) {
+  return (short)x;
+}
+
 Attribute *NCurses_attr_ptr() {
   Attribute* attributes;
   return attributes;

--- a/ncurses_helper.h
+++ b/ncurses_helper.h
@@ -1,5 +1,18 @@
 #include <ncurses.h>
 
+// We need to register a separate type for attributes, as several functions need
+// to use pointers to attributes.
+// In Carp, the pointer type Ptr takes an argument; if the value of this
+// argument begins with a lowercase letter, it will be interpreted as a type
+// parameter instead of a concrete type, so, we need to pass it a type that
+// begins with a capital letter.
+typedef attr_t Attribute;
+
+Attribute *NCurses_attr_ptr() {
+  Attribute* attributes;
+  return attributes;
+}
+
 int NCurses_width() {
     int row, col;
     getmaxyx(stdscr, row, col);

--- a/ncurses_helper.h
+++ b/ncurses_helper.h
@@ -7,6 +7,11 @@
 // parameter instead of a concrete type, so, we need to pass it a type that
 // begins with a capital letter.
 typedef attr_t Attribute;
+// The comments above likewise apply to chtype and short, both of which are used
+// throughout ncurses; for convenience we define counterparts that play well
+// with Carp's compiler here.
+typedef chtype Chtype;
+typedef short Short;
 
 Attribute *NCurses_attr_ptr() {
   Attribute* attributes;


### PR DESCRIPTION
This PR splits up the source into multiple files (since it was getting a bit unwieldy, and it's easier to make target changes). It also:

- Introduces some alias types to make Carp bindings better match the ncurses sources.
- updates `example.carp` based on function changes. 