### PR TITLE
Conditionally define cchar_t

### DIFF
--- a/ncurses_helper.h
+++ b/ncurses_helper.h
@@ -12,8 +12,11 @@ typedef attr_t Attribute;
 // with Carp's compiler here.
 typedef chtype Chtype;
 typedef short Short;
-typedef cchar_t Cchar;
 typedef wchar_t Wchar;
+
+#if NCURSES_WIDECHAR
+typedef cchar_t Cchar;
+#endif
 
 Short NCurses_from_MINUS_int(int x) {
   return (short)x;


### PR DESCRIPTION
This fixes a compilation issue; it turns out ncurses only defines cchar_t if wide character support is turned on.